### PR TITLE
Introduce buffered logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # sha256all
+
 GoLang GoRoutine/channel/waitgroup example. main.go launches 2 types of go routines: 1 sender sends filenames to N receivers that calculate and display the sha256sum.
+
+## Usage
+
+    sha256all [options]... [path]
+
+Examples:
+
+    sha256all /home/user/data
+    sha256all -buffer=true /home/user/data
+    sha256all -cpuprofile=/tmp/prof1 /home/user/data
+
+## CPU profiling
+
+Enable CPU profiling with:
+
+    go run . -cpuprofile=/tmp/prof1 [path]
+
+Inspect the profile:
+
+    go tool pprof -http=:12345 /tmp/prof1

--- a/main.go
+++ b/main.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/sha256"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"sync"
 	"time"
 )
@@ -15,25 +19,28 @@ import (
 // Read from 'filesChan' until channel closes. Calculate sha256sum
 // for each file received.
 func calcSha256(wg *sync.WaitGroup, id int, filesChan chan string) {
+	defer wg.Done()
 	for i := range filesChan {
 		f, err := os.Open(i)
 		if err != nil {
-			log.Fatal(err)
+			logger.Printf("error opening file %s", i)
+			continue
 		}
 
 		h := sha256.New()
 		if _, err := io.Copy(h, f); err != nil {
-			log.Fatal(err)
+			logger.Printf("error calculating sum of %s", i)
+			continue
 		}
 
-		fmt.Printf("%x  %d  %s\n", h.Sum(nil), id, i)
+		logger.Printf("%x  %d  %s\n", h.Sum(nil), id, i)
 	}
-	wg.Done()
 }
 
 // Walk the path provided recursively. Return all filenames found on the
 // 'filesChan' channel
 func walkPath(wg *sync.WaitGroup, root string, filesChan chan string) {
+	defer wg.Done()
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
@@ -42,17 +49,48 @@ func walkPath(wg *sync.WaitGroup, root string, filesChan chan string) {
 		return nil
 	})
 	if err != nil {
-		wg.Done()
 		panic(err)
 	}
 	close(filesChan)
-	wg.Done()
 }
 
+var logger *log.Logger
+
 func main() {
+	var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to given path")
+	var bufferResults = flag.Bool("buffer", false, "buffer results")
+	flag.Parse()
+
+	// Parse optinal root parameter.
+	var root = "../"
+	if userPath := flag.Arg(0); userPath != "" {
+		root = userPath
+	}
+
+	// Set up the logger where given -buffer=true, a buffer of bytes is used
+	// instead of os.Stderr. The buffer is printed before the program ends.
+	var buf bytes.Buffer
+	{
+		var out io.Writer
+		if *bufferResults {
+			out = bufio.NewWriter(&buf)
+		} else {
+			out = os.Stderr
+		}
+
+		logger = log.New(out, "[sha256all] ", log.LstdFlags|log.Lshortfile)
+	}
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		_ = pprof.StartCPUProfile(f)
+	}
+
 	// New waitgroup
 	var wg sync.WaitGroup
-	root := "../"
 	start := time.Now()
 	filesChan := make(chan string)
 
@@ -70,6 +108,17 @@ func main() {
 	// Wait until last thread completes.
 	wg.Wait()
 
+	if *cpuprofile != "" {
+		pprof.StopCPUProfile()
+	}
+
 	elapsed := time.Since(start)
-	fmt.Printf("num cpus used=%d; t=%s\n", numGoRoutines+1, elapsed)
+
+	// Print our buffered logging entries.
+	if *bufferResults {
+		fmt.Println(buf.String())
+	}
+
+	logger.SetOutput(os.Stderr)
+	logger.Printf("num cpus used=%d; t=%s\n", numGoRoutines+1, elapsed)
 }


### PR DESCRIPTION
Logging represents a significant overhead slowing down the computation
phase of the program. This commit introduces an optional buffered logger
that postpones results reporting to the end. Pass `-buffer=true` to use
it.

Optionally, you can pass `-cpuprofile=path` to generate a CPU profile of
the execution. It can be later inspected using the graphs that
`go tool pprof --addr=:12345 path` will show in the browser.

---

![image](https://user-images.githubusercontent.com/606459/98643743-bc07e080-232f-11eb-9247-1aba9bbaf5fa.png)